### PR TITLE
Add a public interface for storing and retrieving the request_id.

### DIFF
--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -22,10 +22,10 @@ module Rack
     end
 
     def call(env)
-      Thread.current[:request_id] = env[REQUEST_ID_HEADER]
+      ::RequestId.request_id = env[REQUEST_ID_HEADER]
       @app.call(env)
     ensure
-      Thread.current[:request_id] = nil
+      ::RequestId.request_id = nil
     end
   end
 end

--- a/lib/request_id.rb
+++ b/lib/request_id.rb
@@ -1,5 +1,36 @@
 require 'request_id/version'
 
+module RequestId
+  class << self
+
+    # Public: Retrieve the current request_id, which is generally set by the
+    # Rack or Sidekiq middleware.
+    #
+    # Examples
+    #
+    #   RequestId.request_id
+    #   # => "0b482498be0d6084d2b634cd6523418d"
+    #
+    # Returns the String request id.
+    def request_id
+      Thread.current[:request_id]
+    end
+
+    # Internal: Set the current request_id.
+    #
+    # Examples
+    #
+    #   RequestId.request_id = SecureRandom.hex
+    #   # => "2297456c027c536d0eb3eb86583fe5a9"
+    #
+    # Returns the new String request id.
+    def request_id=(request_id)
+      Thread.current[:request_id] = request_id
+    end
+
+  end
+end
+
 module Rack
   autoload :RequestId, 'rack/request_id'
 end

--- a/lib/sidekiq/middleware/client/request_id.rb
+++ b/lib/sidekiq/middleware/client/request_id.rb
@@ -24,7 +24,7 @@ module Sidekiq
         end
 
         def request_id
-          Thread.current[:request_id]
+          ::RequestId.request_id
         end
 
       end

--- a/lib/sidekiq/middleware/server/request_id.rb
+++ b/lib/sidekiq/middleware/server/request_id.rb
@@ -4,7 +4,7 @@ module Sidekiq
       class RequestId < Logging
 
         def call(worker, item, queue)
-          request_id = Thread.current[:request_id] = item['request_id']
+          request_id = ::RequestId.request_id = item['request_id']
           Sidekiq::Logging.with_context("request_id=#{request_id} worker=#{worker.class.to_s} jid=#{item['jid']} args=#{item['args'].inspect}") do
             begin
               start = Time.now
@@ -17,7 +17,7 @@ module Sidekiq
             end
           end
         ensure
-          Thread.current[:request_id] = nil
+          ::RequestId.request_id = nil
         end
 
       end


### PR DESCRIPTION
I'd rather not be using Thread.current[:request_id] directly. This hides that behind a public interface.

``` ruby
RequestId.request_id
# => "2297456c027c536d0eb3eb86583fe5a9"
```
