### PR TITLE
Add RequestId.with_request_id.

### DIFF
--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -23,12 +23,11 @@ module Rack
     end
 
     def call(env)
-      ::RequestId.request_id = env[REQUEST_HEADER]
-      status, headers, body = @app.call(env)
-      headers[RESPONSE_HEADER] ||= ::RequestId.request_id
-      [status, headers, body]
-    ensure
-      ::RequestId.request_id = nil
+      ::RequestId.with_request_id(env[REQUEST_HEADER]) do
+        status, headers, body = @app.call(env)
+        headers[RESPONSE_HEADER] ||= ::RequestId.request_id
+        [status, headers, body]
+      end
     end
   end
 end

--- a/lib/request_id.rb
+++ b/lib/request_id.rb
@@ -28,6 +28,28 @@ module RequestId
       Thread.current[:request_id] = request_id
     end
 
+    # Public: Runs the block with the given request id set.
+    #
+    # Examples
+    #
+    #   RequestId.request_id
+    #   # => "9fee77ec37b483983839fe7a753b64d9"
+    #
+    #   RequestId.with_request_id('c8ee330973663097f50686eb17d3324e') do
+    #     RequestId.request_id
+    #     # => "c8ee330973663097f50686eb17d3324e"
+    #   end
+    #
+    #   RequestId.request_id
+    #   # => "9fee77ec37b483983839fe7a753b64d9"
+    def with_request_id(request_id)
+      last_request_id = RequestId.request_id
+      RequestId.request_id = request_id
+      yield
+    ensure
+      RequestId.request_id = last_request_id
+    end
+
   end
 end
 

--- a/spec/request_id_spec.rb
+++ b/spec/request_id_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe RequestId do
+  let(:request_id) { SecureRandom.hex }
+
+  describe '.request_id' do
+    subject { described_class.request_id }
+
+    context 'when Thread.current[:request_id] is set' do
+      before { Thread.current[:request_id] = request_id }
+      it { should eq Thread.current[:request_id] }
+    end
+  end
+
+  describe '.request_id=' do
+    it 'sets Thread.current[:request_id]' do
+      Thread.current.should_receive(:[]=).with(:request_id, request_id)
+      described_class.request_id = request_id
+    end
+  end
+
+  describe '.with_request_id' do
+    before { Thread.current[:request_id] = request_id }
+
+    it 'sets the request_id to the new request_id' do
+      described_class.with_request_id('foobar') do
+        expect(described_class.request_id).to eq 'foobar'
+      end
+      expect(described_class.request_id).to eq request_id
+    end
+  end
+end


### PR DESCRIPTION
I'd like to change our webhooks to keep track of the original request_id (the one kicked off by the user), so I'd like to do this:

``` ruby
desc 'Update the status of a delivery'
params do
  optional :request_id,
    type: String,
    desc: 'The original request_id.',
    default: RequestId.request_id
end
post '/:id/status_callback' do
  authenticate!

  RequestId.with_request_id params.request_id do
    AsyncMethod.perform_async( ... ) if message_status
  end

  status 200
end

```
