### PR TITLE
Generate a request_id in development.

### DIFF
--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Rack
 
   # Public: Rack middleware that stores the Heroku-Request-Id header in a
@@ -23,11 +25,26 @@ module Rack
     end
 
     def call(env)
-      ::RequestId.with_request_id(env[REQUEST_HEADER]) do
+      ::RequestId.with_request_id(request_id(env)) do
         status, headers, body = @app.call(env)
         headers[RESPONSE_HEADER] ||= ::RequestId.request_id
         [status, headers, body]
       end
     end
+
+  private
+
+    def request_id(env)
+      env[REQUEST_HEADER] || generate
+    end
+
+    def generate
+      generate? && SecureRandom.hex(16)
+    end
+
+    def generate?
+      ::RequestId.configuration.generate
+    end
+
   end
 end

--- a/lib/request_id.rb
+++ b/lib/request_id.rb
@@ -1,6 +1,8 @@
 require 'request_id/version'
 
 module RequestId
+  autoload :Configuration, 'request_id/configuration'
+
   class << self
 
     # Public: Retrieve the current request_id, which is generally set by the
@@ -48,6 +50,21 @@ module RequestId
       yield
     ensure
       RequestId.request_id = last_request_id
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # Public: Configure RequestId.
+    #
+    # Examples
+    #
+    #   RequestId.configure do |config|
+    #     config.generate = false
+    #   end
+    def configure
+      yield configuration
     end
 
   end

--- a/lib/request_id/configuration.rb
+++ b/lib/request_id/configuration.rb
@@ -1,0 +1,12 @@
+module RequestId
+  class Configuration
+    # If set to true, the rack middleware will automatically generate a request
+    # id. Useful in development. Defaults to true if this is a rails app an
+    # we're in development.
+    attr_accessor :generate
+
+    def initialize
+      @generate = defined?(Rails) && Rails.env.development?
+    end
+  end
+end


### PR DESCRIPTION
@alexakarpov pointed out that Rack::Lint doesn't play nicely with this in development, since we set X-Request-Id to a nil value. This adds a configuration option to enable or disable generation of a request_id using SecureRandom. By default, it's enabled in Rails when the environment is development.
