### PR TITLE
Only load sidekiq middleware if sidekiq is defined.

### DIFF
--- a/lib/request_id.rb
+++ b/lib/request_id.rb
@@ -1,4 +1,9 @@
 require 'request_id/version'
+require 'request_id/sidekiq' if defined?(Sidekiq)
+
+module Rack
+  autoload :RequestId, 'rack/request_id'
+end
 
 module RequestId
   autoload :Configuration, 'request_id/configuration'
@@ -67,21 +72,5 @@ module RequestId
       yield configuration
     end
 
-  end
-end
-
-module Rack
-  autoload :RequestId, 'rack/request_id'
-end
-
-module Sidekiq
-  module Middleware
-    module Client
-      autoload :RequestId, 'sidekiq/middleware/client/request_id'
-    end
-
-    module Server
-      autoload :RequestId, 'sidekiq/middleware/server/request_id'
-    end
   end
 end

--- a/lib/request_id/sidekiq.rb
+++ b/lib/request_id/sidekiq.rb
@@ -1,0 +1,11 @@
+module Sidekiq
+  module Middleware
+    module Client
+      autoload :RequestId, 'sidekiq/middleware/client/request_id'
+    end
+
+    module Server
+      autoload :RequestId, 'sidekiq/middleware/server/request_id'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+# Ensure the Sidekiq module is defined.
+module Sidekiq; end
+
 require 'bundler/setup'
 Bundler.require :default, :test
 


### PR DESCRIPTION
Only include the sidekiq middleware, if sidekiq is defined. I want to do this so I can maintain the use of `defined?(Sidekiq)` further down the require chain.
