### PR TITLE
Change request header to look at X-Request-Id instead of Heroku-Request-Id

### DIFF
--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -17,7 +17,7 @@ module Rack
   #   logger.info "request_id=#{Thread.current[:request_id]} Hello world"
   #   # => request_id=a08a6712229fb991c0e5026c246862c7 Hello world
   class RequestId
-    REQUEST_HEADER  = 'HTTP_HEROKU_REQUEST_ID'.freeze
+    REQUEST_HEADER  = 'HTTP_X_REQUEST_ID'.freeze
     RESPONSE_HEADER = 'X-Request-Id'.freeze
 
     def initialize(app, options = {})

--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -12,11 +12,11 @@ describe Rack::RequestId do
       Thread.current.should_receive(:[]=).with(:request_id, request_id)
       app.should_receive(:call)
       Thread.current.should_receive(:[]=).with(:request_id, nil)
-      middleware.call('HTTP_HEROKU_REQUEST_ID' => request_id)
+      middleware.call('HTTP_X_REQUEST_ID' => request_id)
     end
 
     it 'sets the X-Request-Id header in the response' do
-      status, headers, body = middleware.call('HTTP_HEROKU_REQUEST_ID' => request_id)
+      status, headers, body = middleware.call('HTTP_X_REQUEST_ID' => request_id)
       expect(headers['X-Request-Id']).to eq request_id
     end
 
@@ -25,7 +25,7 @@ describe Rack::RequestId do
         Thread.current.should_receive(:[]=).with(:request_id, request_id)
         app.should_receive(:call).and_raise
         Thread.current.should_receive(:[]=).with(:request_id, nil)
-        expect { middleware.call('HTTP_HEROKU_REQUEST_ID' => request_id) }.to raise_error
+        expect { middleware.call('HTTP_X_REQUEST_ID' => request_id) }.to raise_error
       end
     end
   end


### PR DESCRIPTION
See https://devcenter.heroku.com/articles/http-request-id#usage-with-ruby-rack-middleware
