### PR TITLE
Add faraday middleware to add the X-Request-Id header.

### DIFF
--- a/lib/faraday/request_id.rb
+++ b/lib/faraday/request_id.rb
@@ -1,0 +1,27 @@
+require 'request_id'
+require 'faraday'
+
+module Faraday
+  class RequestId < Faraday::Middleware
+    HEADER = 'X-Request-Id'.freeze
+
+    def call(env)
+      set_header(env) if needs_header?(env)
+      @app.call(env)
+    end
+
+  private
+
+    def needs_header?(env)
+      request_id && !env[:request_headers][HEADER]
+    end
+
+    def set_header(env)
+      env[:request_headers][HEADER] = request_id
+    end
+
+    def request_id
+      ::RequestId.request_id
+    end
+  end
+end

--- a/request_id.gemspec
+++ b/request_id.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'faraday'
 end

--- a/spec/faraday/request_id_spec.rb
+++ b/spec/faraday/request_id_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'faraday/request_id'
+
+describe Faraday::RequestId do
+  let(:app) { double('app', call: nil) }
+  let(:middleware) { described_class.new(app) }
+
+  describe '.call' do
+    context 'when a request_id is set' do
+      before do
+        RequestId.stub(request_id: SecureRandom.hex)
+      end
+
+      it 'adds the X-Request-Id header' do
+        env = { request_headers: {} }
+        middleware.call(env)
+        expect(env[:request_headers]['X-Request-Id']).to eq RequestId.request_id
+      end
+    end
+
+    context 'when no request_id is set' do
+      before do
+        RequestId.stub(request_id: nil)
+      end
+
+      it 'does not add the X-Request-Id header' do
+        env = { request_headers: {} }
+        middleware.call(env)
+        expect(env[:request_headers]).to_not have_key 'X-Request-Id'
+      end
+    end
+
+    context 'when a request_id is already set in request headers' do
+      let(:request_id) { SecureRandom.hex }
+
+      it 'uses the request id from the env hash' do
+        env = { request_headers: { 'X-Request-Id' => request_id } }
+        middleware.call(env)
+        expect(env[:request_headers]['X-Request-Id']).to eq request_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
Heroku allows you to pass an X-Request-Id header and it will forego generating a new request id and instead use the provided request id. https://devcenter.heroku.com/articles/http-request-id#how-it-works

This adds some faraday middleware to add the X-Request-Id header easily.
