### PR TITLE
Configurable resetting of request_id.

### DIFF
--- a/lib/sidekiq/middleware/server/request_id.rb
+++ b/lib/sidekiq/middleware/server/request_id.rb
@@ -1,7 +1,16 @@
+begin
+  require 'sidekiq/middleware/server/logging'
+rescue LoadError
+  # No sidekiq
+end
+
 module Sidekiq
   module Middleware
     module Server
       class RequestId < Logging
+        class << self
+          attr_accessor :no_reset
+        end
 
         def call(worker, item, queue)
           request_id = ::RequestId.request_id = item['request_id']
@@ -17,7 +26,7 @@ module Sidekiq
             end
           end
         ensure
-          ::RequestId.request_id = nil
+          ::RequestId.request_id = nil unless self.class.no_reset
         end
 
       end


### PR DESCRIPTION
Ensuring that the request_id is reset to nil after processing a job is nice from a cleanliness perspective, but doesn't work properly if we want to have access to the request_id when an exception occurs, since the exception handling in sidekiq 2.17 is handled outside of the middleware chain.

This makes that behavior configurable, so it can be turned off by setting `Sidekiq::Middleware::Server::RequestId.no_reset = true`
