### PR TITLE
Generate request id if none is present

### DIFF
--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -26,7 +26,7 @@ module Rack
     end
 
     def call(env)
-      ::RequestId.with(@options[:key], @options[:value].call(env)) do
+      ::RequestId.with(@options[:key], @options[:value].call(env) || generate) do
         status, headers, body = @app.call(env)
 
         if @options[:response_header]
@@ -42,5 +42,10 @@ module Rack
     def default_options
       { key: :request_id, value: lambda { |env| env[REQUEST_HEADER] }, response_header: RESPONSE_HEADER }
     end
+
+    def generate
+      SecureRandom.uuid if ::RequestId.configuration.generate
+    end
+
   end
 end

--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -21,6 +21,36 @@ describe Rack::RequestId do
       expect(headers['X-Request-Id']).to eq request_id
     end
 
+    context 'when config.generate == false' do
+      before do
+        RequestId.configure { |c| c.generate = false }
+      end
+
+      after do
+        RequestId.configure { |c| c.generate = true }
+      end
+
+      it 'does not generate a request id if none is present' do
+        status, headers, body = middleware.call({})
+        expect(headers['X-Request-Id']).to be_empty
+      end
+    end
+
+    context 'when config.generate == true' do
+      before do
+        RequestId.configure { |c| c.generate = true }
+      end
+
+      after do
+        RequestId.configure { |c| c.generate = false }
+      end
+
+      it 'generates a request id if none is present' do
+        status, headers, body = middleware.call({})
+        expect(headers['X-Request-Id']).to_not be_empty
+      end
+    end
+
     context 'when an exception is raised' do
       it 'still sets the request_id back to nil' do
         Thread.current.should_receive(:[]=).with(:request_id, request_id)


### PR DESCRIPTION
* Use the 'generate' configuration value to determine whether
  to automatically generate a request id if none is present
  in the request headers