### PR TITLE
Fix README to use sidekiq server middleware for the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Sidekiq.configure_server do |config|
   end
 
   config.server_middleware do |chain|
-    chain.add Sidekiq::Middleware::Client::RequestId
+    chain.add Sidekiq::Middleware::Server::RequestId
   end
 end
 ```
@@ -86,7 +86,7 @@ Sidekiq.configure_server do |config|
   end
 
   config.server_middleware do |chain|
-    chain.add Sidekiq::Middleware::Client::RequestId, key: :session_id, value: lambda { |item| item['session_id'] }
+    chain.add Sidekiq::Middleware::Server::RequestId, key: :session_id, value: lambda { |item| item['session_id'] }
   end
 end
 


### PR DESCRIPTION
The sidekiq server needs to retrieve the request_id from the redis data
and set it on Thread.current, not set request_id on the sidekiq client
as the documentation shows.
