### PR TITLE
Fix raise_error deprecation warning

### DIFF
--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -56,7 +56,7 @@ describe Rack::RequestId do
         Thread.current.should_receive(:[]=).with(:request_id, request_id)
         app.should_receive(:call).and_raise
         Thread.current.should_receive(:[]=).with(:request_id, nil)
-        expect { middleware.call('HTTP_X_REQUEST_ID' => request_id) }.to raise_error
+        expect { middleware.call('HTTP_X_REQUEST_ID' => request_id) }.to raise_error(RuntimeError)
       end
     end
   end
@@ -82,7 +82,7 @@ describe Rack::RequestId do
         Thread.current.should_receive(:[]=).with(:session_id, session_id)
         app.should_receive(:call).and_raise
         Thread.current.should_receive(:[]=).with(:session_id, nil)
-        expect { middleware.call('HTTP_X_SESSION_ID' => session_id) }.to raise_error
+        expect { middleware.call('HTTP_X_SESSION_ID' => session_id) }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/sidekiq/middleware/server/request_id_spec.rb
+++ b/spec/sidekiq/middleware/server/request_id_spec.rb
@@ -30,7 +30,7 @@ describe Sidekiq::Middleware::Server::RequestId do
     context 'when an error is raised' do
       it 'ensures that the thread local is set to nil, and raises the error' do
         Thread.current.should_receive(:[]=).with(:request_id, nil).twice
-        expect { middleware.call(worker, {}, nil) { raise } }.to raise_error
+        expect { middleware.call(worker, {}, nil) { raise } }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
Why:

* some specs used `raise_error` without an explicit error class. As a
  result deprecation warnings such as the one below we're being logged

```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the
method you are intending to call. Actual error raised was RuntimeError.
Instead consider providing a specific error class or message. This
message can be suppressed by setting:
`RSpec::Expectations.configuration.on_potential_false_positives =
:nothing`. Called from
/Users/simon/src/github.com/srt32/request_id/spec/rack/request_id_spec.rb:59:in
`block (4 levels) in <top (required)>'.
```

This change addresses the need by:

* explicitly passing error class, which removes the deprecation warning