### PR TITLE
Fix stub should deprecations

### DIFF
--- a/spec/faraday/request_id_spec.rb
+++ b/spec/faraday/request_id_spec.rb
@@ -8,7 +8,7 @@ describe Faraday::RequestId do
   describe '.call' do
     context 'when a request_id is set' do
       before do
-        RequestId.stub(get: SecureRandom.hex)
+        allow(RequestId).to receive(:get).and_return(SecureRandom.hex)
       end
 
       it 'adds the X-Request-Id header' do
@@ -20,7 +20,7 @@ describe Faraday::RequestId do
 
     context 'when no request_id is set' do
       before do
-        RequestId.stub(get: nil)
+        allow(RequestId).to receive(:get).and_return(nil)
       end
 
       it 'does not add the X-Request-Id header' do

--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -10,9 +10,9 @@ describe Rack::RequestId do
     let(:request_id) { SecureRandom.hex }
 
     it 'stores the request_id in a thread local' do
-      Thread.current.should_receive(:[]=).with(:request_id, request_id)
-      app.should_receive(:call)
-      Thread.current.should_receive(:[]=).with(:request_id, nil)
+      expect(Thread.current).to receive(:[]=).with(:request_id, request_id)
+      expect(app).to receive(:call)
+      expect(Thread.current).to receive(:[]=).with(:request_id, nil)
       middleware.call('HTTP_X_REQUEST_ID' => request_id)
     end
 
@@ -53,9 +53,9 @@ describe Rack::RequestId do
 
     context 'when an exception is raised' do
       it 'still sets the request_id back to nil' do
-        Thread.current.should_receive(:[]=).with(:request_id, request_id)
-        app.should_receive(:call).and_raise
-        Thread.current.should_receive(:[]=).with(:request_id, nil)
+        expect(Thread.current).to receive(:[]=).with(:request_id, request_id)
+        expect(app).to receive(:call).and_raise
+        expect(Thread.current).to receive(:[]=).with(:request_id, nil)
         expect { middleware.call('HTTP_X_REQUEST_ID' => request_id) }.to raise_error(RuntimeError)
       end
     end
@@ -66,9 +66,9 @@ describe Rack::RequestId do
     let(:session_id) { SecureRandom.hex }
 
     it 'stores the custom id in a thread local' do
-      Thread.current.should_receive(:[]=).with(:session_id, session_id)
-      app.should_receive(:call)
-      Thread.current.should_receive(:[]=).with(:session_id, nil)
+      expect(Thread.current).to receive(:[]=).with(:session_id, session_id)
+      expect(app).to receive(:call)
+      expect(Thread.current).to receive(:[]=).with(:session_id, nil)
       middleware.call('HTTP_X_SESSION_ID' => session_id)
     end
 
@@ -79,9 +79,9 @@ describe Rack::RequestId do
 
     context 'when an exception is raised' do
       it 'still sets the session_id back to nil' do
-        Thread.current.should_receive(:[]=).with(:session_id, session_id)
-        app.should_receive(:call).and_raise
-        Thread.current.should_receive(:[]=).with(:session_id, nil)
+        expect(Thread.current).to receive(:[]=).with(:session_id, session_id)
+        expect(app).to receive(:call).and_raise
+        expect(Thread.current).to receive(:[]=).with(:session_id, nil)
         expect { middleware.call('HTTP_X_SESSION_ID' => session_id) }.to raise_error(RuntimeError)
       end
     end

--- a/spec/request_id_spec.rb
+++ b/spec/request_id_spec.rb
@@ -15,7 +15,7 @@ describe RequestId do
 
   describe '.request_id=' do
     it 'sets Thread.current[:request_id]' do
-      Thread.current.should_receive(:[]=).with(:request_id, request_id)
+      expect(Thread.current).to receive(:[]=).with(:request_id, request_id)
       described_class.request_id = request_id
     end
   end

--- a/spec/sidekiq/middleware/client/request_id_spec.rb
+++ b/spec/sidekiq/middleware/client/request_id_spec.rb
@@ -17,7 +17,7 @@ describe Sidekiq::Middleware::Client::RequestId do
       end
 
       context 'when the worker is not configured to log request ids' do
-        before { worker.stub get_sidekiq_options: {} }
+        before { allow(worker).to receive(:get_sidekiq_options).and_return({}) }
 
         it 'does not log the request' do
           expect { |b| middleware.call(worker, {}, nil, &b) }.to yield_control

--- a/spec/sidekiq/middleware/server/request_id_spec.rb
+++ b/spec/sidekiq/middleware/server/request_id_spec.rb
@@ -7,7 +7,7 @@ describe Sidekiq::Middleware::Server::RequestId do
   describe '#call' do
     let(:worker) { double('worker') }
 
-    before { worker.stub_chain :class, to_s: 'Worker' }
+    before { allow(worker).to receive_message_chain(:class, :to_s).and_return('Worker') }
 
     context 'when the worker is configured to log request ids' do
       let(:request_id) { SecureRandom.hex }
@@ -15,8 +15,8 @@ describe Sidekiq::Middleware::Server::RequestId do
       let(:item) { { 'jid' => job_id, 'args' => ['foo'], 'request_id' => request_id } }
 
       it 'sets a thread local to the request id' do
-        Thread.current.should_receive(:[]=).with(:request_id, request_id)
-        Thread.current.should_receive(:[]=).with(:request_id, nil)
+        expect(Thread.current).to receive(:[]=).with(:request_id, request_id)
+        expect(Thread.current).to receive(:[]=).with(:request_id, nil)
         expect { |b| middleware.call(worker, item, nil, &b) }.to yield_control
       end
     end
@@ -29,7 +29,7 @@ describe Sidekiq::Middleware::Server::RequestId do
 
     context 'when an error is raised' do
       it 'ensures that the thread local is set to nil, and raises the error' do
-        Thread.current.should_receive(:[]=).with(:request_id, nil).twice
+        expect(Thread.current).to receive(:[]=).with(:request_id, nil).twice
         expect { middleware.call(worker, {}, nil) { raise } }.to raise_error(RuntimeError)
       end
     end


### PR DESCRIPTION
Why:

* running the specs as is led to various warnings like the one below:

```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly
enabling the syntax is deprecated. Use the new `:expect` syntax or
explicitly enable `:should` instead.
```

This change addresses the need by:

* updating the usage of `stub` to fix the deprecation warnings

Thanks!