### PR TITLE
Multiple headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,123 @@
+version: 2
+
+test-parallelism: &TEST_PARALLELISM 1
+
+ruby-image: &RUBY_IMAGE remind101/ruby-ci:2.3.3
+
+all_job_common: &ALL_JOB_COMMON
+  working_directory: ~/request_id
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - bundle_audit_check:
+          requires:
+            - build
+      - rspec:
+          requires:
+            - build
+      - track_rspec_success:
+          requires:
+            - rspec
+
+jobs:
+  build:
+    <<: *ALL_JOB_COMMON
+
+    docker:
+      - image: *RUBY_IMAGE
+
+    steps:
+      - checkout
+
+      - type: cache-restore
+        key: Gemfile.lock-{{ checksum "Gemfile.lock" }}
+      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      - type: cache-save
+        key: Gemfile.lock-{{ checksum "Gemfile.lock" }}
+        paths:
+          - ~/request_id/vendor/bundle
+
+      - run: cp -f config/circleci/database.yml config/database.yml
+
+      # save the entire project. the rest of the steps won't check out the
+      # codebase, but rather will download the source code from the circleci
+      # cache.
+      - persist_to_workspace:
+          root: ~/request_id
+          paths:
+            - .
+
+  bundle_audit_check:
+    <<: *ALL_JOB_COMMON
+
+    docker:
+      - image: *RUBY_IMAGE
+
+    steps:
+      # TODO: get the codebase from the cache and set up bundler. this is
+      # shared between several jobs so we could pull it out.
+      - attach_workspace:
+          at: ~/request_id
+      - run: bundle install --path vendor/bundle
+
+      - run: bundle exec bundle-audit check --update
+
+  rspec:
+    <<: *ALL_JOB_COMMON
+
+    docker:
+      # TODO: can we use yaml references to extract out the following? this is
+      # the same for both rspec and cucumber.
+      - image: *RUBY_IMAGE
+
+    parallelism: *TEST_PARALLELISM
+    steps:
+      # TODO: get the codebase from the cache and set up bundler. this is
+      # shared between several jobs so we could pull it out.
+      - attach_workspace:
+          at: ~/request_id
+
+      # success caching: if the exact same file content had a successful test
+      # run, then skip the tests. good for a quick deploy when tests have
+      # already run against a branch already on top of master.
+      - run: git ls-tree -r HEAD | sort | md5sum > .file-content-sha
+      - type: cache-restore
+        key: rspec-success-{{ checksum ".file-content-sha" }}
+      - run: (test -e /tmp/success/success && circleci step halt) || true
+
+      - run: bundle install --path vendor/bundle
+
+      - run: mkdir -p /tmp/test-results
+
+      - run: circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings > .specs_to_run
+      - run: echo "running $(cat .specs_to_run)"
+      - run: bundle exec rspec --colour --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress $(cat .specs_to_run)
+
+      - store_test_results:
+          path: /tmp/test-results
+
+  # TODO: this is duplicated between rspec and cucumber. isn't there some way
+  # we could extract out this logic?
+  #
+  # this step should require a successful rspec run, because it's going to
+  # record the fact that rspec ran successfully, allowing us to skip subsequent
+  # test runs on the exact same code
+  track_rspec_success:
+    <<: *ALL_JOB_COMMON
+    docker:
+      - image: *RUBY_IMAGE
+
+    steps:
+      # TODO: get the codebase from the cache and set up bundler. this is
+      # shared between several jobs so we could pull it out.
+      - attach_workspace:
+          at: ~/request_id
+      - run: git ls-tree -r HEAD | sort | md5sum > .file-content-sha
+      - run: mkdir -p /tmp/success && touch /tmp/success/success
+      - type: cache-save
+        key: rspec-success-{{ checksum ".file-content-sha" }}
+        paths:
+          - /tmp/success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - bundle_audit_check:
-          requires:
-            - build
       - rspec:
           requires:
             - build
@@ -47,21 +44,6 @@ jobs:
           root: ~/request_id
           paths:
             - .
-
-  bundle_audit_check:
-    <<: *ALL_JOB_COMMON
-
-    docker:
-      - image: *RUBY_IMAGE
-
-    steps:
-      # TODO: get the codebase from the cache and set up bundler. this is
-      # shared between several jobs so we could pull it out.
-      - attach_workspace:
-          at: ~/request_id
-      - run: bundle install --path vendor/bundle
-
-      - run: bundle exec bundle-audit check --update
 
   rspec:
     <<: *ALL_JOB_COMMON

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
       - run: circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings > .specs_to_run
       - run: echo "running $(cat .specs_to_run)"
-      - run: bundle exec rspec --colour --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress $(cat .specs_to_run)
+      - run: bundle exec rspec --colour --profile 10 --out /tmp/test-results/rspec.xml --format progress $(cat .specs_to_run)
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ jobs:
         paths:
           - ~/request_id/vendor/bundle
 
-      - run: cp -f config/circleci/database.yml config/database.yml
-
       # save the entire project. the rest of the steps won't check out the
       # codebase, but rather will download the source code from the circleci
       # cache.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.3.3
+MAINTAINER Terrance Niechciol <terrance@remind101.com>
+
+RUN apt-get update && \
+  apt-get install -y vim && \
+  apt-get -q -y clean && \
+  rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+LABEL app=request_id
+
+RUN gem install bundler
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /home/app
+WORKDIR /home/app
+
+COPY Gemfile /home/app/
+COPY Gemfile.lock /home/app/
+RUN bundle install --jobs 4 --retry 3
+
+COPY . /home/app
+
+CMD ["bundle", "exec", "rails", "console"]

--- a/README.md
+++ b/README.md
@@ -77,35 +77,35 @@ Add the middleware.
 
 ### Customization
 
-You can customize each middleware to store the value of any header you like in the same fashion. For instance,
+You can customize each middleware to store the value of any headers you like in the same fashion. For instance,
 if you wanted to track a `X-Request-Id` header as well as a `X-Session-Id` header, you could do so like this:
 
 ```ruby
 # Rack
 use Rack::RequestId
-use Rack::RequestId, key: :request_id, value: -> (env) { env['HTTP_X_SESSION_ID'], response_header: 'X-Session-Id' }
+use Rack::RequestId, headers: [ { key: :request_id, value: -> (env) { env['HTTP_X_SESSION_ID'], response_header: 'X-Session-Id' } } ]
 
 # Sidekiq
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
     chain.add Sidekiq::Middleware::Client::RequestId
-    chain.add Sidekiq::Middleware::Client::RequestId, key: :session_id, value: -> { ::RequestId.get(:session_id) }
+    chain.add Sidekiq::Middleware::Client::RequestId, headers: [ { key: :session_id, value: -> { ::RequestId.get(:session_id) } } ]
   end
 end
 
 Sidekiq.configure_server do |config|
   config.client_middleware do |chain|
     chain.add Sidekiq::Middleware::Client::RequestId
-    chain.add Sidekiq::Middleware::Client::RequestId, key: :session_id, value: -> { ::RequestId.get(:session_id) }
+    chain.add Sidekiq::Middleware::Client::RequestId, headers: [ { key: :session_id, value: -> { ::RequestId.get(:session_id) } } ]
   end
 
   config.server_middleware do |chain|
-    chain.add Sidekiq::Middleware::Server::RequestId, key: :session_id, value: lambda { |item| item['session_id'] }
+    chain.add Sidekiq::Middleware::Server::RequestId, headers: [ { key: :session_id, value: lambda { |item| item['session_id'] } } ]
   end
 end
 
 # Faraday
-builder.use Faraday::RequestId, key: :session_id, header: 'X-Session-Id'
+builder.use Faraday::RequestId, headers: [ { key: :session_id, header: 'X-Session-Id' } ]
 ```
 
 ## Contributing

--- a/lib/faraday/request_id.rb
+++ b/lib/faraday/request_id.rb
@@ -11,22 +11,24 @@ module Faraday
     end
 
     def call(env)
-      set_header(env) if needs_header?(env)
+      @options[:headers].each do |header|
+        set_header(env, header) if needs_header?(env, header)
+      end
       @app.call(env)
     end
 
   private
 
-    def needs_header?(env)
-      ::RequestId.get(@options[:key]) && !env[:request_headers][@options[:header]]
+    def needs_header?(env, header)
+      ::RequestId.get(header[:key]) && !env[:request_headers][header[:header]]
     end
 
-    def set_header(env)
-      env[:request_headers][@options[:header]] = ::RequestId.get(@options[:key])
+    def set_header(env, header)
+      env[:request_headers][header[:header]] = ::RequestId.get(header[:key])
     end
 
     def default_options
-      { key: :request_id, header: HEADER }
+      { headers: [ { key: :request_id, header: HEADER } ] }
     end
   end
 end

--- a/lib/rack/request_id.rb
+++ b/lib/rack/request_id.rb
@@ -12,7 +12,7 @@ module Rack
   #
   # Examples
   #
-  #   use Rack::RequestId, key: :request_id, value: -> (env) { env['HTTP_X_REQUEST_ID'] }, response_header: 'X-Request-Id'
+  #   use Rack::RequestId, headers: [ { key: :request_id, value: -> (env) { env['HTTP_X_REQUEST_ID'] }, response_header: 'X-Request-Id' } ]
   #
   #   logger.info "request_id=#{RequestId.request_id} Hello world"
   #   # => request_id=a08a6712229fb991c0e5026c246862c7 Hello world
@@ -26,11 +26,13 @@ module Rack
     end
 
     def call(env)
-      ::RequestId.with(@options[:key], @options[:value].call(env) || generate) do
+      ::RequestId.with(options_with_resolved_values(env)) do
         status, headers, body = @app.call(env)
 
-        if @options[:response_header]
-          headers[@options[:response_header]] ||= ::RequestId.get(@options[:key]).to_s
+        @options[:headers].each do |h|
+          if h[:response_header]
+            headers[h[:response_header]] ||= ::RequestId.get(h[:key]).to_s
+          end
         end
 
         [status, headers, body]
@@ -39,8 +41,14 @@ module Rack
 
   private
 
+    def options_with_resolved_values(env)
+      @options[:headers].map do |header|
+        { key: header[:key], value: header[:value].call(env) || generate}
+      end
+    end
+
     def default_options
-      { key: :request_id, value: lambda { |env| env[REQUEST_HEADER] }, response_header: RESPONSE_HEADER }
+      { headers: [ { key: :request_id, value: lambda { |env| env[REQUEST_HEADER] }, response_header: RESPONSE_HEADER } ] }
     end
 
     def generate

--- a/lib/request_id/version.rb
+++ b/lib/request_id/version.rb
@@ -1,3 +1,3 @@
 module RequestId
-  VERSION = '0.5.0'
+  VERSION = '1.0.0'
 end

--- a/lib/request_id/version.rb
+++ b/lib/request_id/version.rb
@@ -1,3 +1,3 @@
 module RequestId
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end

--- a/lib/sidekiq/middleware/client/request_id.rb
+++ b/lib/sidekiq/middleware/client/request_id.rb
@@ -7,22 +7,16 @@ module Sidekiq
         end
 
         def call(worker, item, queue, redis_pool = nil)
-          item[id_key] = id_value if id_value
+          @options[:headers].each do |kv|
+            item[kv[:key].to_s] = kv[:value].call() if kv[:value]
+          end
           yield
         end
 
       private
 
-        def id_key
-          @options[:key].to_s
-        end
-
-        def id_value
-          @options[:value].call()
-        end
-
         def default_options
-          { key: :request_id, value: lambda { ::RequestId.request_id } }
+          { headers: [ { key: :request_id, value: lambda { ::RequestId.request_id } } ] }
         end
       end
     end

--- a/lib/sidekiq/middleware/server/request_id.rb
+++ b/lib/sidekiq/middleware/server/request_id.rb
@@ -17,16 +17,20 @@ module Sidekiq
         end
 
         def call(worker, item, queue)
-          ::RequestId.set(@options[:key], @options[:value].call(item))
+          @options[:headers].each do |kv|
+            ::RequestId.set(kv[:key], kv[:value].call(item))
+          end
           yield
         ensure
-          ::RequestId.set(@options[:key], nil) unless self.class.no_reset
+          @options[:headers].each do |kv|
+            ::RequestId.set(kv[:key], nil) unless self.class.no_reset
+          end
         end
 
         private
 
           def default_options
-            { key: :request_id, value: lambda { |item| item['request_id'] } }
+            { headers: [ { key: :request_id, value: lambda { |item| item['request_id'] } } ] }
           end
       end
     end

--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 
 describe Rack::RequestId do
   let(:app) { double('app', call: [200, {}, ['Body']]) }
-  let(:config) { { key: :request_id, value: lambda { |env| env['HTTP_X_REQUEST_ID'] }, response_header: 'X-Request-Id' } }
+  let(:config) { { headers: [ { key: :request_id, value: lambda { |env| env['HTTP_X_REQUEST_ID'] }, response_header: 'X-Request-Id' } ] } }
   let(:middleware) { described_class.new app, config }
 
   describe '.call' do
@@ -62,7 +62,7 @@ describe Rack::RequestId do
   end
 
   describe 'custom middleware configuration' do
-    let(:config) { { key: :session_id, value: lambda { |env| env['HTTP_X_SESSION_ID'] }, response_header: 'X-Session-Id' } }
+    let(:config) { { headers: [ { key: :session_id, value: lambda { |env| env['HTTP_X_SESSION_ID'] }, response_header: 'X-Session-Id' } ] } }
     let(:session_id) { SecureRandom.hex }
 
     it 'stores the custom id in a thread local' do

--- a/spec/rack/request_id_spec.rb
+++ b/spec/rack/request_id_spec.rb
@@ -62,27 +62,35 @@ describe Rack::RequestId do
   end
 
   describe 'custom middleware configuration' do
-    let(:config) { { headers: [ { key: :session_id, value: lambda { |env| env['HTTP_X_SESSION_ID'] }, response_header: 'X-Session-Id' } ] } }
+    let(:config) { { headers: [
+      { key: :session_id, value: lambda { |env| env['HTTP_X_SESSION_ID'] }, response_header: 'X-Session-Id' },
+      { key: :client_id, value: lambda { |env| env['HTTP_X_CLIENT_ID'] }, response_header: 'X-Client-Id' } ] } }
     let(:session_id) { SecureRandom.hex }
+    let(:client_id) { SecureRandom.hex }
 
     it 'stores the custom id in a thread local' do
       expect(Thread.current).to receive(:[]=).with(:session_id, session_id)
+      expect(Thread.current).to receive(:[]=).with(:client_id, client_id)
       expect(app).to receive(:call)
       expect(Thread.current).to receive(:[]=).with(:session_id, nil)
-      middleware.call('HTTP_X_SESSION_ID' => session_id)
+      expect(Thread.current).to receive(:[]=).with(:client_id, nil)
+      middleware.call({ 'HTTP_X_SESSION_ID' => session_id, 'HTTP_X_CLIENT_ID' => client_id })
     end
 
-    it 'sets the X-Session-Id header in the response' do
-      status, headers, body = middleware.call('HTTP_X_SESSION_ID' => session_id)
+    it 'sets the X-Session-Id and X-Client-Id headers in the response' do
+      status, headers, body = middleware.call({ 'HTTP_X_SESSION_ID' => session_id, 'HTTP_X_CLIENT_ID' => client_id})
       expect(headers['X-Session-Id']).to eq session_id
+      expect(headers['X-Client-Id']).to eq client_id
     end
 
     context 'when an exception is raised' do
       it 'still sets the session_id back to nil' do
         expect(Thread.current).to receive(:[]=).with(:session_id, session_id)
+        expect(Thread.current).to receive(:[]=).with(:client_id, client_id)
         expect(app).to receive(:call).and_raise
         expect(Thread.current).to receive(:[]=).with(:session_id, nil)
-        expect { middleware.call('HTTP_X_SESSION_ID' => session_id) }.to raise_error(RuntimeError)
+        expect(Thread.current).to receive(:[]=).with(:client_id, nil)
+        expect { middleware.call({ 'HTTP_X_SESSION_ID' => session_id, 'HTTP_X_CLIENT_ID' => client_id}) }.to raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
Adds support for multiple headers to be passed along. This changes the interface from:

```
chain.add Sidekiq::Middleware::Server::RequestId, key: :session_id, value: lambda { |item| item['session_id'] }
```

to

```
chain.add Sidekiq::Middleware::Server::RequestId, headers: [ { key: :session_id, value: lambda { |item| item['session_id'] } } ]
```

I've tested this against a branch of r101-api that saves multiple headers using this new interface (on staging), and it all worked :ok_hand:

Edit: Oh since I see this doesn't have a circle integration, I should add that I've run the spec tests locally and everything was green.