### PR TITLE
CI: Use defaults, add new Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-script: bundle exec rake
+  - 2.5.5
+  - 2.6.3
+  


### PR DESCRIPTION
This PR changes the Travis CI configuration to use defaults, and adds two new Ruby versions.